### PR TITLE
log login errors for easier debugging on failure

### DIFF
--- a/main.js
+++ b/main.js
@@ -134,6 +134,8 @@ ipcMain.on('pokemon-login', (event, method, username, password) => {
 
     win.loadURL(`file://${__dirname}/home.html`)
     win.setSize(900, 600, true)
+  }).catch(error => {
+    console.error(error)
   })
 })
 // END OF LOGIN


### PR DESCRIPTION
I couldn't login because my google account has 2 factor authentication which was throwing a 403 and requiring the use of an [AppPassword](https://security.google.com/settings/security/apppasswords). I didn't realize this because the errors weren't displayed anywhere. For now this will show any login failures in the console. Eventually it will be useful to display the error message in the app itself.
