### PR TITLE
#27 Max Candy and Stardust

### DIFF
--- a/js/screens/Table/index.jsx
+++ b/js/screens/Table/index.jsx
@@ -90,7 +90,13 @@ function prepDisplay (d) {
 
     poke.td_checkbox = checkBox + '>'
 
-    let tip = `Stardust Cost = ${poke.stardust_cost} <br> Candy Cost = ${poke.candy_cost} <br> CP After ≅ ${Math.round(poke.next_cp) + poke.cp}`
+    let tip = `
+    Stardust Cost = ${poke.stardust_cost} <br>
+    Candy Cost = ${poke.candy_cost} <br>
+    CP After ≅ ${Math.round(poke.next_cp) + poke.cp} <br>
+    Max Stardust = ${poke.stardust_max_cost} <br>
+    Max Candy = ${poke.candy_max_cost}
+    `
 
     let tooltip = 'data-toggle="tooltip" data-placement="right" data-html=true title="' + tip + '"'
     poke.td_powerup = '<a id="powerUp" data-pokemon-id="' + poke.id + '" data-nickname="' + poke.nickname + '" ' + tooltip + '>P↑</a>'

--- a/main/main.js
+++ b/main/main.js
@@ -243,8 +243,10 @@ ipcMain.on('get-players-pokemons', (event) => {
       let stamina = stats.BaseStamina + pokemon['individual_stamina']
 
       let maxCP = utils.getMaxCpForTrainerLevel(attack, defense, stamina, player.level)
-      let candyCost = utils.getCandyCostsForPowerup(totalCpMultiplier, pokemon['num_upgrades'])
-      let stardustCost = utils.getStardustCostsForPowerup(totalCpMultiplier, pokemon['num_upgrades'])
+      let candyCost = utils.getCandyCostsForPowerup(totalCpMultiplier, pokemon.num_upgrades)
+      let stardustCost = utils.getStardustCostsForPowerup(totalCpMultiplier, pokemon.num_upgrades)
+      let candyMaxCost = utils.getMaxCandyCostsForPowerup(player.level, pokemon.num_upgrades, pokemon.cp_multiplier)
+      let stardustMaxCost = utils.getMaxStardustCostsForPowerup(player.level, pokemon.num_upgrades, pokemon.cp_multiplier)
       let nextCP = utils.getCpAfterPowerup(pokemon['cp'], totalCpMultiplier)
 
       reducedPokemonList.push({
@@ -252,7 +254,9 @@ ipcMain.on('get-players-pokemons', (event) => {
         next_cp: nextCP,
         max_cp: maxCP,
         candy_cost: candyCost,
+        candy_max_cost: candyMaxCost,
         stardust_cost: stardustCost,
+        stardust_max_cost: stardustMaxCost,
         creation_time_ms: pokemon['creation_time_ms'].toString(),
         deployed: pokemon['deployed_fort_id'] !== '',
         id: pokemon['id'].toString(),

--- a/main/utils.js
+++ b/main/utils.js
@@ -100,26 +100,19 @@ function getMaxCostsForPowerup (trainerLevel, powerups, pokemonsCPMultiplier, tr
   let maxLevelOfPokemon = trainerLevel + allowedLevelsAbovePlayer
   let currentLevelOfPokemon = utils.getLevelFromCpMultiplier(pokemonsCPMultiplier)
 
-  let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) //* 2
+  let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) * 2
 
   let total = 0
   let upgrades = 0
 
-  for (let key in levelCpMultiplier) {
-    if (parseFloat(key) >= currentLevelOfPokemon) {
-      if (upgrades === numberOfUpgrades) break
-      total += transform(levelCpMultiplier[key], powerups)
-      upgrades++
-    }
-  }
-
   // just making an iterable array out of the numberOfUpgrades value
-  // Array.apply(null, Array(numberOfUpgrades)).forEach((v, i) => {
-  //   let multiplier = levelCpMultiplier[i + currentLevelOfPokemon]
-  //   total += utils.getCandyCostsForPowerup(multiplier, powerups)
-  // })
+  Array.apply(null, Array(numberOfUpgrades)).forEach((v, index) => {
+    let level = ((index + 1) * .5) + currentLevelOfPokemon
+    let multiplier = levelCpMultiplier[level]
+    total += transform(multiplier, powerups)
+  })
 
-  return total * 2
+  return total
 }
 
 let utils = {
@@ -225,14 +218,6 @@ let utils = {
       return (cp * 0.008924905903) / Math.pow(cpMultiplier, 2)
     }
     return (cp * 0.00445946079) / Math.pow(cpMultiplier, 2)
-  },
-  testy: () => {
-    return [
-      utils.getMaxCandyCostsForPowerup(20, 0, 0.5974000096321106),
-      utils.getMaxStardustCostsForPowerup(20, 0, 0.5974000096321106),
-      utils.getMaxCandyCostsForPowerup(20, 0, 0.5507926940917969),
-      utils.getMaxStardustCostsForPowerup(20, 0, 0.5507926940917969)
-    ]
   },
   getMaxCandyCostsForPowerup: (trainerLevel, powerups, pokemonsCPMultiplier, upgradesPerLevel, allowedLevelsAbovePlayer) => {
     return getMaxCostsForPowerup(trainerLevel, powerups, pokemonsCPMultiplier, utils.getCandyCostsForPowerup, upgradesPerLevel, allowedLevelsAbovePlayer)

--- a/main/utils.js
+++ b/main/utils.js
@@ -199,6 +199,31 @@ let utils = {
       return (cp * 0.008924905903) / Math.pow(cpMultiplier, 2)
     }
     return (cp * 0.00445946079) / Math.pow(cpMultiplier, 2)
+  },
+  getMaxCandyCostsForPowerup: (trainerLevel, powerups, pokemonsCPMultiplier, upgradesPerLevel = 2, allowedLevelsAbovePlayer = 2) => {
+    let maxLevelOfPokemon = trainerLevel + allowedLevelsAbovePlayer
+    let currentLevelOfPokemon = utils.getLevelFromCpMultiplier(pokemonsCPMultiplier)
+
+    let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) //* 2
+
+    let total = 0
+    let upgrades = 0
+
+    for (let key in levelCpMultiplier) {
+      if (parseFloat(key) >= currentLevelOfPokemon) {
+        if (upgrades === numberOfUpgrades) break
+        total += utils.getCandyCostsForPowerup(levelCpMultiplier[key], powerups)
+        upgrades++
+      }
+    }
+    // just making an iterable array out of the numberOfUpgrades value
+    // Array.apply(null, Array(numberOfUpgrades)).forEach((v, i) => {
+    //   console.log(v, i)
+    //   let multiplier = levelCpMultiplier[i + currentLevelOfPokemon]
+    //   total += utils.getCandyCostsForPowerup(multiplier, powerups)
+    // })
+
+    return total * 2
   }
 }
 

--- a/main/utils.js
+++ b/main/utils.js
@@ -97,19 +97,34 @@ function getLevel (cpMultiplier) {
 }
 
 function getMaxCostsForPowerup (trainerLevel, powerups, pokemonsCPMultiplier, transform, upgradesPerLevel = 2, allowedLevelsAbovePlayer = 2) {
+  // The Maximum Level this pokemon can reach
   let maxLevelOfPokemon = trainerLevel + allowedLevelsAbovePlayer
+  // The current level of the pokemon based on its `cp_multiplier` property
   let currentLevelOfPokemon = utils.getLevelFromCpMultiplier(pokemonsCPMultiplier)
 
-  let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) * upgradesPerLevel
+  // Number of Upgrades to Maximum
+  // So if your current level was 3 and if it could max at 20, that would be 17 Upgrades * 2 Upl - 1 = 33 Upgrades
+  let numberOfUpgrades = ((maxLevelOfPokemon - currentLevelOfPokemon) * upgradesPerLevel) - 1
 
-  let total = 0
+  // initialize our total cost for candies or dust
+  let total = transform(levelCpMultiplier[currentLevelOfPokemon], powerups)
+  powerups++
+
+  // The difference between any two adjacent levels +-
+  let levelSize = .5
 
   for (let i = 0; i < numberOfUpgrades; i++) {
+    // The number that represents the current upgrade
     let upgradeNumber = i + 1
-    let levelSize = .5
+    // The level the pokemon will become if upgraded
+    // currentLevelOfPokemon could be 3, if the index is 0, upgradeNumber is 1
+    // so we get (1 * .5) + 3
     let level = (upgradeNumber * levelSize) + currentLevelOfPokemon
+    // the number of power ups previously applied and the number we are applying
+    // so if you used 4, the first index is 0 so 4
     let currentPowerUps = powerups + i
 
+    // a candy or dust cost calculated from a levels cp multiplier and the current number of power ups used
     total += transform(levelCpMultiplier[level], currentPowerUps)
   }
 
@@ -133,61 +148,61 @@ let utils = {
   getStardustCostsForPowerup: (cpMultiplier, powerups) => {
     let level = utils.getLevelFromCpMultiplier(cpMultiplier)
 
-    if (level <= 3 && powerups <= 4) {
+    if (level <= 2.5 && powerups <= 4) {
       return 200
     }
-    if (level <= 4 && powerups <= 8) {
+    if (level <= 4.5 && powerups <= 8) {
       return 400
     }
-    if (level <= 7 && powerups <= 12) {
+    if (level <= 6.5 && powerups <= 12) {
       return 600
     }
-    if (level <= 8 && powerups <= 16) {
+    if (level <= 8.5 && powerups <= 16) {
       return 800
     }
-    if (level <= 11 && powerups <= 20) {
+    if (level <= 10.5 && powerups <= 20) {
       return 1000
     }
-    if (level <= 13 && powerups <= 24) {
+    if (level <= 12.5 && powerups <= 24) {
       return 1300
     }
-    if (level <= 15 && powerups <= 28) {
+    if (level <= 14.5 && powerups <= 28) {
       return 1600
     }
-    if (level <= 17 && powerups <= 32) {
+    if (level <= 16.5 && powerups <= 32) {
       return 1900
     }
-    if (level <= 19 && powerups <= 36) {
+    if (level <= 18.5 && powerups <= 36) {
       return 2200
     }
-    if (level <= 21 && powerups <= 40) {
+    if (level <= 20.5 && powerups <= 40) {
       return 2500
     }
-    if (level <= 23 && powerups <= 44) {
+    if (level <= 22.5 && powerups <= 44) {
       return 3000
     }
-    if (level <= 25 && powerups <= 48) {
+    if (level <= 24.5 && powerups <= 48) {
       return 3500
     }
-    if (level <= 27 && powerups <= 52) {
+    if (level <= 26.5 && powerups <= 52) {
       return 4000
     }
-    if (level <= 29 && powerups <= 56) {
+    if (level <= 28.5 && powerups <= 56) {
       return 4500
     }
-    if (level <= 31 && powerups <= 60) {
+    if (level <= 30.5 && powerups <= 60) {
       return 5000
     }
-    if (level <= 33 && powerups <= 64) {
+    if (level <= 32.5 && powerups <= 64) {
       return 6000
     }
-    if (level <= 35 && powerups <= 68) {
+    if (level <= 34.5 && powerups <= 68) {
       return 7000
     }
-    if (level <= 37 && powerups <= 72) {
+    if (level <= 36.5 && powerups <= 72) {
       return 8000
     }
-    if (level <= 39 && powerups <= 76) {
+    if (level <= 38.5 && powerups <= 76) {
       return 9000
     }
     return 10000
@@ -195,13 +210,13 @@ let utils = {
   getCandyCostsForPowerup: (cpMultiplier, powerups) => {
     let level = utils.getLevelFromCpMultiplier(cpMultiplier)
 
-    if (level <= 13 && powerups <= 20) {
+    if (level <= 10.5 && powerups <= 20) {
       return 1
     }
-    if (level <= 21 && powerups <= 36) {
+    if (level <= 20.5 && powerups <= 36) {
       return 2
     }
-    if (level <= 31 && powerups <= 60) {
+    if (level <= 30.5 && powerups <= 60) {
       return 3
     }
     return 4

--- a/main/utils.js
+++ b/main/utils.js
@@ -148,61 +148,61 @@ let utils = {
   getStardustCostsForPowerup: (cpMultiplier, powerups) => {
     let level = utils.getLevelFromCpMultiplier(cpMultiplier)
 
-    if (level <= 2.5 && powerups <= 4) {
+    if (level <= 2.5 && powerups <= 5) {
       return 200
     }
-    if (level <= 4.5 && powerups <= 8) {
+    if (level <= 4.5 && powerups <= 9) {
       return 400
     }
-    if (level <= 6.5 && powerups <= 12) {
+    if (level <= 6.5 && powerups <= 13) {
       return 600
     }
-    if (level <= 8.5 && powerups <= 16) {
+    if (level <= 8.5 && powerups <= 17) {
       return 800
     }
-    if (level <= 10.5 && powerups <= 20) {
+    if (level <= 10.5 && powerups <= 21) {
       return 1000
     }
-    if (level <= 12.5 && powerups <= 24) {
+    if (level <= 12.5 && powerups <= 25) {
       return 1300
     }
-    if (level <= 14.5 && powerups <= 28) {
+    if (level <= 14.5 && powerups <= 29) {
       return 1600
     }
-    if (level <= 16.5 && powerups <= 32) {
+    if (level <= 16.5 && powerups <= 33) {
       return 1900
     }
-    if (level <= 18.5 && powerups <= 36) {
+    if (level <= 18.5 && powerups <= 37) {
       return 2200
     }
-    if (level <= 20.5 && powerups <= 40) {
+    if (level <= 20.5 && powerups <= 41) {
       return 2500
     }
-    if (level <= 22.5 && powerups <= 44) {
+    if (level <= 22.5 && powerups <= 45) {
       return 3000
     }
-    if (level <= 24.5 && powerups <= 48) {
+    if (level <= 24.5 && powerups <= 49) {
       return 3500
     }
-    if (level <= 26.5 && powerups <= 52) {
+    if (level <= 26.5 && powerups <= 53) {
       return 4000
     }
-    if (level <= 28.5 && powerups <= 56) {
+    if (level <= 28.5 && powerups <= 57) {
       return 4500
     }
-    if (level <= 30.5 && powerups <= 60) {
+    if (level <= 30.5 && powerups <= 61) {
       return 5000
     }
-    if (level <= 32.5 && powerups <= 64) {
+    if (level <= 32.5 && powerups <= 65) {
       return 6000
     }
-    if (level <= 34.5 && powerups <= 68) {
+    if (level <= 34.5 && powerups <= 69) {
       return 7000
     }
-    if (level <= 36.5 && powerups <= 72) {
+    if (level <= 36.5 && powerups <= 73) {
       return 8000
     }
-    if (level <= 38.5 && powerups <= 76) {
+    if (level <= 38.5 && powerups <= 77) {
       return 9000
     }
     return 10000
@@ -210,16 +210,31 @@ let utils = {
   getCandyCostsForPowerup: (cpMultiplier, powerups) => {
     let level = utils.getLevelFromCpMultiplier(cpMultiplier)
 
-    if (level <= 10.5 && powerups <= 20) {
+    if (level <= 10.5 && powerups <= 21) {
       return 1
     }
-    if (level <= 20.5 && powerups <= 36) {
+    if (level <= 20.5 && powerups <= 41) {
       return 2
     }
-    if (level <= 30.5 && powerups <= 60) {
+    if (level <= 25.5 && powerups <= 51) {
       return 3
     }
-    return 4
+    if (level <= 30.5 && powerups <= 61) {
+      return 4
+    }
+    if (level <= 32.5 && powerups <= 65) {
+      return 6
+    }
+    if (level <= 34.5 && powerups <= 69) {
+      return 8
+    }
+    if (level <= 36.5 && powerups <= 73) {
+      return 10
+    }
+    if (level <= 38.5 && powerups <= 77) {
+      return 12
+    }
+    return 15
   },
   getCpAfterPowerup: (cp, cpMultiplier) => {
     let level = utils.getLevelFromCpMultiplier(cpMultiplier)

--- a/main/utils.js
+++ b/main/utils.js
@@ -103,8 +103,8 @@ function getMaxCostsForPowerup (trainerLevel, powerups, pokemonsCPMultiplier, tr
   let currentLevelOfPokemon = utils.getLevelFromCpMultiplier(pokemonsCPMultiplier)
 
   // Number of Upgrades to Maximum
-  // So if your current level was 3 and if it could max at 20, that would be 17 Upgrades * 2 Upl - 1 = 33 Upgrades
-  let numberOfUpgrades = ((maxLevelOfPokemon - currentLevelOfPokemon) * upgradesPerLevel) - 1
+  // So if your current level was 3 and if it could max at 20, that would be 17 Upgrades * 2 Upl = 34 Upgrades
+  let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) * upgradesPerLevel
 
   // initialize our total cost for candies or dust
   let total = transform(levelCpMultiplier[currentLevelOfPokemon], powerups)

--- a/main/utils.js
+++ b/main/utils.js
@@ -108,7 +108,7 @@ function getMaxCostsForPowerup (trainerLevel, powerups, pokemonsCPMultiplier, tr
     let upgradeNumber = i + 1
     let levelSize = .5
     let level = (upgradeNumber * levelSize) + currentLevelOfPokemon
-    let currentPowerUps = powerups + upgradeNumber
+    let currentPowerUps = powerups + i
 
     total += transform(levelCpMultiplier[level], currentPowerUps)
   }

--- a/main/utils.js
+++ b/main/utils.js
@@ -96,6 +96,32 @@ function getLevel (cpMultiplier) {
   return Math.round((level) * 2) / 2.0
 }
 
+function getMaxCostsForPowerup (trainerLevel, powerups, pokemonsCPMultiplier, transform, upgradesPerLevel = 2, allowedLevelsAbovePlayer = 2) {
+  let maxLevelOfPokemon = trainerLevel + allowedLevelsAbovePlayer
+  let currentLevelOfPokemon = utils.getLevelFromCpMultiplier(pokemonsCPMultiplier)
+
+  let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) //* 2
+
+  let total = 0
+  let upgrades = 0
+
+  for (let key in levelCpMultiplier) {
+    if (parseFloat(key) >= currentLevelOfPokemon) {
+      if (upgrades === numberOfUpgrades) break
+      total += transform(levelCpMultiplier[key], powerups)
+      upgrades++
+    }
+  }
+
+  // just making an iterable array out of the numberOfUpgrades value
+  // Array.apply(null, Array(numberOfUpgrades)).forEach((v, i) => {
+  //   let multiplier = levelCpMultiplier[i + currentLevelOfPokemon]
+  //   total += utils.getCandyCostsForPowerup(multiplier, powerups)
+  // })
+
+  return total * 2
+}
+
 let utils = {
   levelCpMultiplier: levelCpMultiplier,
   getLevelFromCpMultiplier: (multiplier) => {
@@ -200,30 +226,19 @@ let utils = {
     }
     return (cp * 0.00445946079) / Math.pow(cpMultiplier, 2)
   },
-  getMaxCandyCostsForPowerup: (trainerLevel, powerups, pokemonsCPMultiplier, upgradesPerLevel = 2, allowedLevelsAbovePlayer = 2) => {
-    let maxLevelOfPokemon = trainerLevel + allowedLevelsAbovePlayer
-    let currentLevelOfPokemon = utils.getLevelFromCpMultiplier(pokemonsCPMultiplier)
-
-    let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) //* 2
-
-    let total = 0
-    let upgrades = 0
-
-    for (let key in levelCpMultiplier) {
-      if (parseFloat(key) >= currentLevelOfPokemon) {
-        if (upgrades === numberOfUpgrades) break
-        total += utils.getCandyCostsForPowerup(levelCpMultiplier[key], powerups)
-        upgrades++
-      }
-    }
-    // just making an iterable array out of the numberOfUpgrades value
-    // Array.apply(null, Array(numberOfUpgrades)).forEach((v, i) => {
-    //   console.log(v, i)
-    //   let multiplier = levelCpMultiplier[i + currentLevelOfPokemon]
-    //   total += utils.getCandyCostsForPowerup(multiplier, powerups)
-    // })
-
-    return total * 2
+  testy: () => {
+    return [
+      utils.getMaxCandyCostsForPowerup(20, 0, 0.5974000096321106),
+      utils.getMaxStardustCostsForPowerup(20, 0, 0.5974000096321106),
+      utils.getMaxCandyCostsForPowerup(20, 0, 0.5507926940917969),
+      utils.getMaxStardustCostsForPowerup(20, 0, 0.5507926940917969)
+    ]
+  },
+  getMaxCandyCostsForPowerup: (trainerLevel, powerups, pokemonsCPMultiplier, upgradesPerLevel, allowedLevelsAbovePlayer) => {
+    return getMaxCostsForPowerup(trainerLevel, powerups, pokemonsCPMultiplier, utils.getCandyCostsForPowerup, upgradesPerLevel, allowedLevelsAbovePlayer)
+  },
+  getMaxStardustCostsForPowerup: (trainerLevel, powerups, pokemonsCPMultiplier, upgradesPerLevel, allowedLevelsAbovePlayer) => {
+    return getMaxCostsForPowerup(trainerLevel, powerups, pokemonsCPMultiplier, utils.getStardustCostsForPowerup, upgradesPerLevel, allowedLevelsAbovePlayer)
   }
 }
 

--- a/main/utils.js
+++ b/main/utils.js
@@ -100,7 +100,7 @@ function getMaxCostsForPowerup (trainerLevel, powerups, pokemonsCPMultiplier, tr
   let maxLevelOfPokemon = trainerLevel + allowedLevelsAbovePlayer
   let currentLevelOfPokemon = utils.getLevelFromCpMultiplier(pokemonsCPMultiplier)
 
-  let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) * 2
+  let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) * upgradesPerLevel
 
   let total = 0
 

--- a/main/utils.js
+++ b/main/utils.js
@@ -103,14 +103,11 @@ function getMaxCostsForPowerup (trainerLevel, powerups, pokemonsCPMultiplier, tr
   let numberOfUpgrades = (maxLevelOfPokemon - currentLevelOfPokemon) * 2
 
   let total = 0
-  let upgrades = 0
 
-  // just making an iterable array out of the numberOfUpgrades value
-  Array.apply(null, Array(numberOfUpgrades)).forEach((v, index) => {
-    let level = ((index + 1) * .5) + currentLevelOfPokemon
-    let multiplier = levelCpMultiplier[level]
-    total += transform(multiplier, powerups)
-  })
+  for (let i = 0; i < numberOfUpgrades; i++) {
+    let level = ((i + 1) * .5) + currentLevelOfPokemon
+    total += transform(levelCpMultiplier[level], powerups)
+  }
 
   return total
 }

--- a/main/utils.js
+++ b/main/utils.js
@@ -105,8 +105,12 @@ function getMaxCostsForPowerup (trainerLevel, powerups, pokemonsCPMultiplier, tr
   let total = 0
 
   for (let i = 0; i < numberOfUpgrades; i++) {
-    let level = ((i + 1) * .5) + currentLevelOfPokemon
-    total += transform(levelCpMultiplier[level], powerups)
+    let upgradeNumber = i + 1
+    let levelSize = .5
+    let level = (upgradeNumber * levelSize) + currentLevelOfPokemon
+    let currentPowerUps = powerups + upgradeNumber
+
+    total += transform(levelCpMultiplier[level], currentPowerUps)
   }
 
   return total


### PR DESCRIPTION
@Wrexial and @mackhankins let me know what you think of this so far. It is doing what I wanted it to, but I don't think I am getting the right costs yet, which may have something to do with the functions from Blossom. If you look at http://pokemongo.gamepress.gg/power-up-costs It seems a bit off from those numbers.

I am sure that iterating with `numOfUpgrades` works properly. I just think that calculated costs for stardust and candies is off somehow.
## Some Test Results

Charmander

``` bash
(max level, current level, numberOfUpgrades)
Candy Stats: 22 20 4
(level, index, total candy)
20.5 0 2
21 1 4
21.5 2 7
22 3 10

(max level, current level, numberOfUpgrades)
Stardust Stats: 22 20 4
(level, index, total dust)
20.5 0 2500
21 1 5000
21.5 2 8000
22 3 11000
```

Bulbasaur

``` bash
(max level, current level, numberOfUpgrades)
Candy Stats: 22 17 10
(level, index, total candy)
17.5 0 2
18 1 4
18.5 2 6
19 3 8
19.5 4 10
20 5 12
20.5 6 14
21 7 16
21.5 8 19
22 9 22

(max level, current level, numberOfUpgrades)
Stardust Stats: 22 17 10
(level, index, total dust)
17.5 0 2200
18 1 4400
18.5 2 6600
19 3 8800
19.5 4 11300
20 5 13800
20.5 6 16300
21 7 18800
21.5 8 21800
22 9 24800
```

If you look at the first result, you can see the candies go from 2 to 4 to 7 to 10 (2 + 2 + 3 + 3). From levels 20.5-22. So in just 4 levels it calculates 10 candies. But based on the power up costs site from 20.5 to 22 it should be 2 to 5 to 8 to 11 (2 + 3 + 3 + 3). I am not sure who is right or wrong here since we are pinning Blossoms code vs the Power Up Costs from gamepress. Let me know your thoughts.
