### PR TITLE
Updated evolution time to match app update

### DIFF
--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -372,8 +372,8 @@ function transferSelectedPokemon(selectedPokemon) {
 
 function evolveSelectedPokemon(selectedPokemon) {
   const method = 'Evolve'
-  const time = selectedPokemon.length * 27.5
-  const delayRange = [25, 30]
+  const time = selectedPokemon.length * 22.5
+  const delayRange = [20, 25]
   const action = evolvePokemon
 
   return processSelectedPokemon(selectedPokemon, method, action, time, delayRange)


### PR DESCRIPTION
It seems like the evolution animation is around 17-18 seconds before the user regains control. I've padded two seconds to the delay range to cater for user scrolling or device lag. Let me know if this is enough.
