### PR TITLE
Fix the count for totalCandyNeeded and extraPokemonNeeded

### DIFF
--- a/app/screens/Table/components/Species.js
+++ b/app/screens/Table/components/Species.js
@@ -154,7 +154,7 @@ class Species extends React.Component {
           extraCandyNeededSpan = (
             <span
               className="additional-info"
-              alt="Extra candy required to evolve all pokemon"
+              title="Extra candy required to evolve all pokemon"
             >
               {` +${extraCandyNeeded}`}
             </span>
@@ -163,7 +163,7 @@ class Species extends React.Component {
           extraPokemonNeededSpan = (
             <span
               className="additional-info"
-              alt="Extra pokemon required to use all candy"
+              title="Extra pokemon required to use all candy"
             >
               {` +${extraPokemonNeeded}`}
             </span>

--- a/app/screens/Table/components/Species.js
+++ b/app/screens/Table/components/Species.js
@@ -146,9 +146,9 @@ class Species extends React.Component {
       let extraPokemonNeededSpan
 
       if (specie.evolves > 0) {
-        const totalCandyNeeded = specie.candyToEvolve * specie.count
+        const totalCandyNeeded = (specie.candyToEvolve - 1) * specie.count + 1
         const extraCandyNeeded = totalCandyNeeded - specie.candy
-        const extraPokemonNeeded = Math.floor((extraCandyNeeded * -1) / specie.candyToEvolve)
+        const extraPokemonNeeded = Math.floor((extraCandyNeeded * -1) / (specie.candyToEvolve - 1))
 
         if (extraCandyNeeded > 0) {
           extraCandyNeededSpan = (


### PR DESCRIPTION
I'm pretty sure `totalCandyNeeded` is now correct. Not so much about `extraPokemonNeeded` (maybe it was already correct the way it was before?). I will need you to check it out and confirm, @YesThatAllen.