### PR TITLE
Fix batch transfer

### DIFF
--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -457,8 +457,8 @@ function handlePogobufError(error) {
 
 function transferPokemon(selectedPokemon) {
   return async (dispatch) => {
-    let idArray = []
-    let monArray = []
+    const idArray = []
+    const monArray = []
     for (let i = 0; i < selectedPokemon.length; i++) {
       idArray[i] = selectedPokemon[i].id
       monArray[i] = selectedPokemon[i]

--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -457,15 +457,10 @@ function handlePogobufError(error) {
 
 function transferPokemon(selectedPokemon) {
   return async (dispatch) => {
-    const idArray = []
-    const monArray = []
-    selectedPokemon.forEach((currentPokemon) => {
-      idArray.push(currentPokemon.id)
-      monArray.push(currentPokemon)
-    })
+    const ids = selectedPokemon.map(p => p.id)
     try {
-      await getClient().releasePokemon(idArray)
-      dispatch(transferPokemonSuccess(monArray))
+      await getClient().releasePokemon(ids)
+      dispatch(transferPokemonSuccess(selectedPokemon))
     } catch (error) {
       dispatch(transferPokemonFailed(error))
       handlePogobufError(error)
@@ -533,7 +528,7 @@ function batchProcessSelectedPokemon(method, batchMethod, selectedPokemon) {
   }
 }
 
-const transferSelectedPokemon = transferPokemon.bind('releasePokemon')
+const transferSelectedPokemon = transferPokemon
 const evolveSelectedPokemon = batchProcessSelectedPokemon.bind(null, 'Evolve', 'evolvePokemon')
 
 export default {

--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -470,7 +470,7 @@ function transferPokemon(pokemon, delay) {
 
 function transferMultiplePokemon(selectedPokemon) {
   return async (dispatch) => {
-    for (var i = 0; i < selectedPokemon.length; i++) {
+    for (let i = 0; i < selectedPokemon.length; i++) {
       try {
         await getClient().releasePokemon(selectedPokemon[i].id)
         dispatch(transferPokemonSuccess(selectedPokemon[i]))

--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -459,7 +459,7 @@ function transferPokemon(selectedPokemon) {
   return async (dispatch) => {
     const idArray = []
     const monArray = []
-    selectedPokemon.forEach(function(currentPokemon) {
+    selectedPokemon.forEach((currentPokemon) => {
       idArray.push(currentPokemon.id)
       monArray.push(currentPokemon)
     })

--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -455,29 +455,20 @@ function handlePogobufError(error) {
   }
 }
 
-function transferPokemon(pokemon, delay) {
+function transferPokemon(selectedPokemon) {
   return async (dispatch) => {
+    let idArray = []
+    let monArray = []
+    for (let i = 0; i < selectedPokemon.length; i++) {
+      idArray[i] = selectedPokemon[i].id
+      monArray[i] = selectedPokemon[i]
+    }
     try {
-      await sleep(delay)
-      await getClient().releasePokemon(pokemon.id)
-      dispatch(transferPokemonSuccess(pokemon))
+      await getClient().releasePokemon(idArray)
+      dispatch(transferPokemonSuccess(monArray))
     } catch (error) {
       dispatch(transferPokemonFailed(error))
       handlePogobufError(error)
-    }
-  }
-}
-
-function transferMultiplePokemon(selectedPokemon) {
-  return async (dispatch) => {
-    for (let i = 0; i < selectedPokemon.length; i++) {
-      try {
-        await getClient().releasePokemon(selectedPokemon[i].id)
-        dispatch(transferPokemonSuccess(selectedPokemon[i]))
-      } catch (error) {
-        dispatch(transferPokemonFailed(error))
-        handlePogobufError(error)
-      }
     }
     await dispatch(refreshPokemon())
   }
@@ -542,8 +533,7 @@ function batchProcessSelectedPokemon(method, batchMethod, selectedPokemon) {
   }
 }
 
-const transferSelectedPokemon = transferMultiplePokemon.bind('releasePokemon')
-
+const transferSelectedPokemon = transferPokemon.bind('releasePokemon')
 const evolveSelectedPokemon = batchProcessSelectedPokemon.bind(null, 'Evolve', 'evolvePokemon')
 
 export default {

--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -468,6 +468,21 @@ function transferPokemon(pokemon, delay) {
   }
 }
 
+function transferMultiplePokemon(selectedPokemon) {
+  return async (dispatch) => {
+    for (var i = 0; i < selectedPokemon.length; i++) {
+      try {
+        await getClient().releasePokemon(selectedPokemon[i].id)
+        dispatch(transferPokemonSuccess(selectedPokemon[i]))
+      } catch (error) {
+        dispatch(transferPokemonFailed(error))
+        handlePogobufError(error)
+      }
+    }
+    await dispatch(refreshPokemon())
+  }
+}
+
 function evolvePokemon(pokemon, delay) {
   return async (dispatch) => {
     try {
@@ -527,7 +542,7 @@ function batchProcessSelectedPokemon(method, batchMethod, selectedPokemon) {
   }
 }
 
-const transferSelectedPokemon = batchProcessSelectedPokemon.bind(null, 'Transfer', 'releasePokemon')
+const transferSelectedPokemon = transferMultiplePokemon.bind('releasePokemon')
 
 const evolveSelectedPokemon = batchProcessSelectedPokemon.bind(null, 'Evolve', 'evolvePokemon')
 

--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -469,16 +469,22 @@ function transferPokemon(selectedPokemon) {
   }
 }
 
-function evolvePokemon(pokemon, delay) {
+function evolvePokemon(selectedPokemon) {
   return async (dispatch) => {
-    try {
-      await sleep(delay)
-      await getClient().evolvePokemon(pokemon.id)
-      dispatch(evolvePokemonSuccess(pokemon))
-    } catch (error) {
-      dispatch(evolvePokemonFailed(error))
-      handlePogobufError(error)
-    }
+    const delayMin = 4000
+    const delayMax = 12000
+    selectedPokemon.forEach(async (currentPokemon) => {
+      try {
+        await getClient().evolvePokemon(currentPokemon.id)
+        // Wait for a random number of seconds between delayMin and delayMax, both included
+        await sleep(Math.floor(Math.random() * (delayMax - delayMin + 1)) + delayMin)
+        dispatch(evolvePokemonSuccess(currentPokemon))
+      } catch (error) {
+        dispatch(evolvePokemonFailed(error))
+        handlePogobufError(error)
+      }
+    })
+    await dispatch(refreshPokemon())
   }
 }
 
@@ -529,7 +535,7 @@ function batchProcessSelectedPokemon(method, batchMethod, selectedPokemon) {
 }
 
 const transferSelectedPokemon = transferPokemon
-const evolveSelectedPokemon = batchProcessSelectedPokemon.bind(null, 'Evolve', 'evolvePokemon')
+const evolveSelectedPokemon = evolvePokemon
 
 export default {
   updateMonster,

--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -459,10 +459,10 @@ function transferPokemon(selectedPokemon) {
   return async (dispatch) => {
     const idArray = []
     const monArray = []
-    for (let i = 0; i < selectedPokemon.length; i++) {
-      idArray[i] = selectedPokemon[i].id
-      monArray[i] = selectedPokemon[i]
-    }
+    selectedPokemon.forEach(function(currentPokemon) {
+      idArray.push(currentPokemon.id)
+      monArray.push(currentPokemon)
+    })
     try {
       await getClient().releasePokemon(idArray)
       dispatch(transferPokemonSuccess(monArray))

--- a/app/actions/trainer.js
+++ b/app/actions/trainer.js
@@ -465,6 +465,7 @@ function transferPokemon(selectedPokemon) {
       dispatch(transferPokemonFailed(error))
       handlePogobufError(error)
     }
+    ipcRenderer.send('information-dialog', 'Complete!', `Finished Transfer`)
     await dispatch(refreshPokemon())
   }
 }
@@ -484,6 +485,7 @@ function evolvePokemon(selectedPokemon) {
         handlePogobufError(error)
       }
     })
+    ipcRenderer.send('information-dialog', 'Complete!', `Finished Evolve`)
     await dispatch(refreshPokemon())
   }
 }
@@ -514,25 +516,25 @@ function resetStatusAndGetPokemon(errorMessage) {
   }
 }
 
-function batchProcessSelectedPokemon(method, batchMethod, selectedPokemon) {
-  return async (dispatch) => {
-    dispatch(updateStatus({
-      method,
-      selectedPokemon: null,
-      time: null,
-    }))
+// function batchProcessSelectedPokemon(method, batchMethod, selectedPokemon) {
+//   return async (dispatch) => {
+//     dispatch(updateStatus({
+//       method,
+//       selectedPokemon: null,
+//       time: null,
+//     }))
 
-    const batchCall = batchStart(selectedPokemon, batchMethod)
+//     const batchCall = batchStart(selectedPokemon, batchMethod)
 
-    try {
-      await batchCall()
-      await dispatch(resetStatusAndGetPokemon())
-      ipcRenderer.send('information-dialog', 'Complete!', `Finished ${method}`)
-    } catch (e) {
-      dispatch(resetStatusAndGetPokemon(`Error while running ${method.toLowerCase()}:\n\n${e}`))
-    }
-  }
-}
+//     try {
+//       await batchCall()
+//       await dispatch(resetStatusAndGetPokemon())
+//       ipcRenderer.send('information-dialog', 'Complete!', `Finished ${method}`)
+//     } catch (e) {
+//       dispatch(resetStatusAndGetPokemon(`Error while running ${method.toLowerCase()}:\n\n${e}`))
+//     }
+//   }
+// }
 
 const transferSelectedPokemon = transferPokemon
 const evolveSelectedPokemon = evolvePokemon

--- a/app/reducers/trainer.js
+++ b/app/reducers/trainer.js
@@ -326,9 +326,9 @@ export default handleActions({
   },
 
   TRANSFER_POKEMON_SUCCESS(state, action) {
-    const pokemon = action.payload
-    for (let i = 0; i < pokemon.length; i++) {
-      console.info(`Transferred ${pokemon[i].id}`) // eslint-disable-line
+    const selectedPokemon = action.payload
+    selectedPokemon.forEach((currentPokemon) => {
+      console.info(`Transferred ${currentPokemon.id}`) // eslint-disable-line
     }
     return state
   },

--- a/app/reducers/trainer.js
+++ b/app/reducers/trainer.js
@@ -327,7 +327,9 @@ export default handleActions({
 
   TRANSFER_POKEMON_SUCCESS(state, action) {
     const pokemon = action.payload
-    console.info(`Transferred ${pokemon.id}`) // eslint-disable-line
+    for (let i = 0; i < pokemon.length; i++) {
+      console.info(`Transferred ${pokemon[i].id}`) // eslint-disable-line
+    }
     return state
   },
 

--- a/app/reducers/trainer.js
+++ b/app/reducers/trainer.js
@@ -329,7 +329,7 @@ export default handleActions({
     const selectedPokemon = action.payload
     selectedPokemon.forEach((currentPokemon) => {
       console.info(`Transferred ${currentPokemon.id}`) // eslint-disable-line
-    }
+    })
     return state
   },
 


### PR DESCRIPTION
This works but transfers the selected mons one by one without any delays. We should change it so it uses the native batch-transfer method Pokémon GO uses when users select multiple mons from the selection screen like explained here: https://github.com/cyraxx/pogobuf/wiki/pogobuf.Client-Pok%C3%A9mon-Go-API-Methods#releasepokemonpokemonids--promise