### PR TITLE
Login requires hashing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ Note: Only 12 characters can be used to rename a pokemon.
     yarn run package-all
 
 ## FAQ
-1. Will I be banned from pokemon go for using PokeNurse?
-
+1. **Will I be banned from pokemon go for using PokeNurse?**  
 This app is meant to make pogo easier to manage. This is not a bot. We do not send location data. No one has ever been banned for using PokeNurse as far as we are aware. This doesn't mean you cannot be banned, if they somehow begin to detect API calls from pogobuf, then this may very well start happening, but that is the risk of using any of these third party tools right now that are not the original app.
+
+2. **What is this `hashingKey` PokeNurse asks for?**  
+The API Hashing service is a paid service that allows third party Pokémon GO developers to build awesome tools for the game. Most of this tools were free to use in the past but, because of some changes Niantic introduced, there's no way to use them anymore without a Hashing Key license. You can learn more about what they are and how much they cost [from this website](https://talk.pogodev.org/d/51-api-hashing-service-by-pokefarmer).
 
 ## Known Issues
 * Google 2 Factor Authentication cannot be used. However you can use an [AppPassword](https://security.google.com/settings/security/apppasswords) instead.

--- a/app/reducers/authenticate.js
+++ b/app/reducers/authenticate.js
@@ -25,6 +25,8 @@ function getAccountCredentials() {
     method: credentials.method,
     username: credentials.username,
     password: credentials.password,
+    hashingKey: credentials.hashingKey,
+    apiVersion: credentials.apiVersion,
   }
 }
 

--- a/app/screens/Login/components/LoginFormContainer.js
+++ b/app/screens/Login/components/LoginFormContainer.js
@@ -29,7 +29,7 @@ const AUTH_METHODS = {
 
 const hashKeyTooltip = (
   <Tooltip id="hashKeyTooltip">
-    This is a safer way to interact with the API.
+    This is the only way to interact with the API.
     Hash Keys currently have varying costs based on your Requests per Minute.
   </Tooltip>
 )

--- a/app/screens/Login/components/LoginFormContainer.js
+++ b/app/screens/Login/components/LoginFormContainer.js
@@ -230,6 +230,11 @@ class LoginForm extends React.Component {
       return
     }
 
+    if (!hashingKey) {
+      ipcRenderer.send('error-message', 'A hashingKey is required to login.')
+      return
+    }
+
     const credentials = {
       method,
       username,


### PR DESCRIPTION
As sugested by @vinnymac in #212 , PokéNurse ~~for~~ now requires you to use a hashing key in order to login. This will avoid the possibility of accounts getting flagged for trying to use the old API. This will also reduce the amount of issues getting opened to report login errors.

To avoid getting more issues asking what this `hashingKey` is, we should probably change what we show here (and write about it in `README.md`):

<img width="840" alt="captura de pantalla 2017-03-15 a las 2 08 05" src="https://cloud.githubusercontent.com/assets/1107521/23929160/6305e0a0-0924-11e7-9279-b22fd16b6ac4.png">

This fixes #213 and fixes #216